### PR TITLE
Allow for comments at the end of a line.

### DIFF
--- a/src/Configuration/Dotenv/Parse.purs
+++ b/src/Configuration/Dotenv/Parse.purs
@@ -49,7 +49,7 @@ name = unfoldToString <$> (manyTill anyChar $ char '=')
 
 -- | Parses an unquoted variable value.
 unquotedValue :: Parser String (List Char)
-unquotedValue = manyTill anyChar (lookAhead eol <|> eof)
+unquotedValue = manyTill anyChar ((lookAhead comment *> pure unit) <|> lookAhead eol <|> eof)
 
 -- | Parses a quoted variable value enclosed within the specified type of quotation mark.
 quotedValue :: Char -> Parser String (List Char)

--- a/test/Parse.purs
+++ b/test/Parse.purs
@@ -26,6 +26,9 @@ tests = describe "configParser" do
   it "skips commented lines" $
     parse "# Comment\nA=B\n# Comment\n# Comment\nC=D" `shouldEqual` success [ Tuple "A" "B", Tuple "C" "D" ]
 
+  it "skips comments after a variable" $
+    parse "A=a\nB=b # Testing" `shouldEqual` success [ Tuple "A" "a", Tuple "B" "b" ]
+
   it "parses empty values as empty strings" $
     parse "A=" `shouldEqual` success [ Tuple "A" "" ]
 


### PR DESCRIPTION
This allows for a comment to appear at the end of a variable line, i.e.

```
VAR_NAME=var_value # Comment
```