### PR TITLE
Factor out NEA due to no significant benefit.

### DIFF
--- a/src/Dotenv/Internal/Resolve.purs
+++ b/src/Dotenv/Internal/Resolve.purs
@@ -4,7 +4,6 @@ module Dotenv.Internal.Resolve (values) where
 
 import Prelude
 import Control.Alt ((<|>))
-import Data.Array.NonEmpty (toArray)
 import Data.Bifunctor (rmap)
 import Data.Foldable (find)
 import Data.Maybe (Maybe)
@@ -27,7 +26,7 @@ value env settings val =
   in
     case val of
       LiteralValue v            -> pure v
-      ValueExpression vs        -> joinWith "" <$> (sequence $ toArray $ value' <$> vs)
+      ValueExpression vs        -> joinWith "" <$> (sequence $ value' <$> vs)
       VariableSubstitution name -> lookup name env <|> (value' =<< snd <$> find (eq name <<< fst) settings)
 
 -- | Given the environment and an array of `.env` settings, resolves the value of each setting.

--- a/src/Dotenv/Internal/Types.purs
+++ b/src/Dotenv/Internal/Types.purs
@@ -3,7 +3,6 @@
 module Dotenv.Internal.Types (Environment, Name, Setting, Settings, Value(..)) where
 
 import Prelude
-import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Tuple (Tuple)
 import Foreign.Object (Object)
 
@@ -11,7 +10,7 @@ import Foreign.Object (Object)
 type Name = String
 
 -- | The value of a setting
-data Value = LiteralValue String | VariableSubstitution String | ValueExpression (NonEmptyArray Value)
+data Value = LiteralValue String | VariableSubstitution String | ValueExpression (Array Value)
 
 derive instance eqValue :: Eq Value
 

--- a/test/Parse.purs
+++ b/test/Parse.purs
@@ -1,7 +1,6 @@
 module Test.Parse (tests) where
 
 import Prelude
-import Data.Array.NonEmpty (cons')
 import Data.Either (Either(..))
 import Data.Tuple (Tuple(..))
 import Dotenv.Internal.Parse (settings)
@@ -86,9 +85,7 @@ tests = describe "settings parser" do
   it "parses variable substitutions" $
     let
       expected =
-        Right
-          [ Tuple "A" $ ValueExpression $ cons' (LiteralValue "Hi, ") [ VariableSubstitution "USER", LiteralValue "!" ]
-          ]
+        Right [ Tuple "A" $ ValueExpression [ LiteralValue "Hi, ", VariableSubstitution "USER", LiteralValue "!" ] ]
       actual = "A=Hi, ${USER}!" `runParser` settings
     in
       actual `shouldEqual` expected

--- a/test/Resolve.purs
+++ b/test/Resolve.purs
@@ -1,7 +1,6 @@
 module Test.Resolve (tests) where
 
 import Prelude
-import Data.Array.NonEmpty (cons')
 import Data.Foldable (find)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..), fst, snd)
@@ -20,15 +19,15 @@ settings = Resolve.values (singleton "DB_PASSWORD" "asdf") $
   , Tuple "DB_PASS" $ VariableSubstitution "DB_PASSWORD"
   , Tuple "DB_NAME" $ LiteralValue "development"
   , Tuple "DB_CRED" $
-      ValueExpression $ cons'
-        ( VariableSubstitution "DB_USER" )
-        [ LiteralValue ":"
+      ValueExpression
+        [ VariableSubstitution "DB_USER"
+        , LiteralValue ":"
         , VariableSubstitution "DB_PASS"
         ]
   , Tuple "DB_CONNECTION_STRING" $
-      ValueExpression $ cons'
-        ( LiteralValue "db://" )
-        [ VariableSubstitution "DB_CRED"
+      ValueExpression
+        [ LiteralValue "db://"
+        , VariableSubstitution "DB_CRED"
         , LiteralValue "@"
         , VariableSubstitution "DB_HOST"
         , LiteralValue "/"


### PR DESCRIPTION
`NonEmptyArray` isn't providing any meaningful benefit in this library, but it requires more (and more awkward) code to use it.