### PR TITLE
Just run in Aff like other libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Next, import the `Dotenv` module at the entry point of your program (i.e. `Main.
 import Dotenv (loadFile) as Dotenv
 ```
 
-The `loadFile` function is designed to run in [`Aff`](http://github.com/slamdata/purescript-aff), so you will also need to import something like `launchAff_`:
+The `loadFile` function runs in [`Aff`](https://pursuit.purescript.org/packages/purescript-aff/5.1.1/docs/Effect.Aff#t:Aff), so you will also need to import something like [`launchAff_`](https://pursuit.purescript.org/packages/purescript-aff/5.1.1/docs/Effect.Aff#v:launchAff_):
 
 ```purescript
 import Effect.Aff (launchAff_)


### PR DESCRIPTION
`MonadAff m => MonadError Error m => m a` and `Aff a` are roughly equivalent in that I believe the latter is in practice the only concretization of the former. I think this is why other libraries just simplify the type signature to `Aff`. (Affjax is the last example of this I checked.)