### PR TITLE
Fix parser handling of escaped quotes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Handling of escaped quotes (#39 by @nsaunders)
 
 Other improvements:
 

--- a/src/Dotenv/Internal/Parse.purs
+++ b/src/Dotenv/Internal/Parse.purs
@@ -70,7 +70,7 @@ quotedValue q =
   let
     literal =
       LiteralValue <<< fromCharArray <$> some
-        ( noneOf [ '$', q ] <|> try
+        ( (try $ char '\\' *> char q *> pure q) <|> noneOf [ '$', q ] <|> try
             (char '$' <* notFollowedBy (oneOf [ '{', '(' ]))
         )
   in

--- a/test/Parse.purs
+++ b/test/Parse.purs
@@ -54,10 +54,24 @@ tests = describe "settings (parser)" do
     in
       actual `shouldEqual` expected
 
+  it "parses escaped single quotes" $
+    let
+      expected = Right [ Tuple "A" $ LiteralValue "'a'" ]
+      actual = "A='\\'a\\''" `runParser` settings
+    in
+      actual `shouldEqual` expected
+
   it "parses double-quoted values" $
     let
       expected = Right [ Tuple "A" $ LiteralValue "a" ]
       actual = "A=\"a\"" `runParser` settings
+    in
+      actual `shouldEqual` expected
+
+  it "parses escaped double quotes" $
+    let
+      expected = Right [ Tuple "A" $ LiteralValue "\"a\"" ]
+      actual = "A=\"\\\"a\\\"\"" `runParser` settings
     in
       actual `shouldEqual` expected
 


### PR DESCRIPTION
The `.env` file may include single- or double-quoted values, e.g.

```
FOO="FOO value"
BAR='BAR value'
```

In either case, I would expect escaped quotes to work, e.g.

```
FOO="\"FOO\" value"
BAR='\'BAR\' value'
```

However, this is not currently the case prior to this PR.