### PR TITLE
Selective resolution; resolves #33 and #38.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 ## [Unreleased]
 
 Breaking changes:
+- `loadFile` and `loadContents` now return `Aff Unit`. (#40 by @nsaunders)
 
 New features:
 
@@ -12,6 +13,7 @@ Bugfixes:
 - Handling of escaped quotes (#39 by @nsaunders)
 
 Other improvements:
+- Unused values are no longer resolved. (#40 by @nsaunders)
 
 ## [3.0.0] - 2022-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 Breaking changes:
 - `loadFile` and `loadContents` now return `Aff Unit`. (#40 by @nsaunders)
 
+  > **Note**
+  > Although this is technically a breaking change, existing code that discards the return value will continue to work without modification, e.g.
+  > ```purescript
+  > _ <- loadFile -- Still works, although there is no need to explicitly discard `Unit`.
+  > ```
+
 New features:
 
 Bugfixes:

--- a/examples/Basic.purs
+++ b/examples/Basic.purs
@@ -11,7 +11,7 @@ import Node.Process (lookupEnv)
 
 main :: Effect Unit
 main = launchAff_ do
-  _ <- Dotenv.loadFile
+  Dotenv.loadFile
   liftEffect do
     greeting <- lookupEnv "GREETING"
     logShow greeting

--- a/examples/Contents.purs
+++ b/examples/Contents.purs
@@ -11,5 +11,5 @@ import Node.Process (lookupEnv)
 
 main :: Effect Unit
 main = launchAff_ do
-  _ <- Dotenv.loadContents """GREETING="Hello, Sailor!" """
+  Dotenv.loadContents """GREETING="Hello, Sailor!" """
   liftEffect $ lookupEnv "GREETING" >>= logShow

--- a/examples/Validation.purs
+++ b/examples/Validation.purs
@@ -28,7 +28,7 @@ readConfig env = { greeting: _, count: _ }
 
 main :: Effect Unit
 main = launchAff_ do
-  _ <- Dotenv.loadFile
+  Dotenv.loadFile
   liftEffect do
     eitherConfig <- readConfig <$> getEnv
     case eitherConfig of

--- a/src/Dotenv/Internal/Apply.purs
+++ b/src/Dotenv/Internal/Apply.purs
@@ -1,24 +1,29 @@
 -- | This module encapsulates the logic for applying settings to the environment.
 
-module Dotenv.Internal.Apply (applySettings) where
+module Dotenv.Internal.Apply (apply) where
 
 import Prelude
 
-import Data.Maybe (fromMaybe, isJust)
-import Data.Traversable (traverse)
-import Data.Tuple (Tuple(..))
+import Data.Array (filter) as A
+import Data.Maybe (isNothing)
+import Data.Traversable (for_, traverse_)
+import Data.Tuple.Nested ((/\))
+import Dotenv.Internal.ChildProcess (CHILD_PROCESS)
 import Dotenv.Internal.Environment (ENVIRONMENT, lookupEnv, setEnv)
-import Dotenv.Internal.Types (ResolvedValue, Setting)
+import Dotenv.Internal.Resolve (resolve)
+import Dotenv.Internal.Types (Setting, UnresolvedValue)
 import Run (Run)
+import Type.Row (type (+))
 
 -- | Applies the specified settings to the environment.
-applySettings
+apply
   :: forall r
-   . Array (Setting ResolvedValue)
-  -> Run (ENVIRONMENT r) (Array (Setting ResolvedValue))
-applySettings = traverse \(Tuple name resolvedValue) -> do
-  currentValue <- lookupEnv name
-  if isJust currentValue then pure $ Tuple name currentValue
-  else do
-    when (isJust resolvedValue) (setEnv name $ fromMaybe "" resolvedValue)
-    pure $ Tuple name resolvedValue
+   . Array (Setting UnresolvedValue)
+  -> Run (CHILD_PROCESS + ENVIRONMENT + r) Unit
+apply settings =
+  for_ settings \(name /\ unresolvedValue) -> do
+    currentValue <- lookupEnv name
+    when (isNothing currentValue) do
+      maybeValue <- resolve (A.filter (\(name' /\ _) -> name /= name') settings)
+        unresolvedValue
+      traverse_ (setEnv name) maybeValue

--- a/src/Dotenv/Internal/Resolve.purs
+++ b/src/Dotenv/Internal/Resolve.purs
@@ -1,15 +1,16 @@
 -- | This module encapsulates the logic for resolving `.env` values.
 
-module Dotenv.Internal.Resolve (resolveValues) where
+module Dotenv.Internal.Resolve
+  ( resolve
+  ) where
 
 import Prelude
 
-import Data.Array (unzip, zip)
 import Data.Foldable (find)
 import Data.Maybe (Maybe(..))
 import Data.String (joinWith, trim)
 import Data.Traversable (sequence, traverse)
-import Data.Tuple (Tuple(..), fst, snd)
+import Data.Tuple (fst, snd)
 import Dotenv.Internal.ChildProcess (CHILD_PROCESS, spawn)
 import Dotenv.Internal.Environment (ENVIRONMENT, lookupEnv)
 import Dotenv.Internal.Types (ResolvedValue, Setting, UnresolvedValue(..))
@@ -17,12 +18,12 @@ import Run (Run)
 import Type.Row (type (+))
 
 -- | Resolves a value according to its expression.
-resolveValue
+resolve
   :: forall r
    . Array (Setting UnresolvedValue)
   -> UnresolvedValue
   -> Run (CHILD_PROCESS + ENVIRONMENT + r) ResolvedValue
-resolveValue settings = case _ of
+resolve settings = case _ of
   LiteralValue value ->
     pure $ Just value
   CommandSubstitution cmd args -> do
@@ -36,20 +37,9 @@ resolveValue settings = case _ of
       Nothing -> do
         case (snd <$> find (eq var <<< fst) settings) of
           Just unresolvedValue ->
-            resolveValue settings unresolvedValue
+            resolve settings unresolvedValue
           Nothing ->
             pure Nothing
   ValueExpression unresolvedValues -> do
-    resolvedValues <- traverse (resolveValue settings) unresolvedValues
+    resolvedValues <- traverse (resolve settings) unresolvedValues
     pure $ joinWith "" <$> sequence resolvedValues
-
--- | Resolves the values within an array of settings.
-resolveValues
-  :: forall r
-   . Array (Setting UnresolvedValue)
-  -> Run (CHILD_PROCESS + ENVIRONMENT + r) (Array (Setting ResolvedValue))
-resolveValues settings =
-  let
-    (Tuple names unresolvedValues) = unzip settings
-  in
-    zip names <$> traverse (resolveValue settings) unresolvedValues

--- a/src/Dotenv/Internal/Types.purs
+++ b/src/Dotenv/Internal/Types.purs
@@ -7,7 +7,7 @@ import Prelude
 import Data.Maybe (Maybe)
 import Data.Tuple (Tuple)
 
--- | The name of a setting
+-- | The name of a setting name
 type Name = String
 
 -- | The expressed value of a setting, which has not been resolved yet


### PR DESCRIPTION
The main goal of this PR is to avoid resolving unused values.

Consider the following example:

```
GREETING="Hello, $(whoami)"
```

Previously, even if the `GREETING` variable was set (i.e. `.env` fallback not used), the `whoami` command would be run in a child process.

After this change, the `whoami` command will no longer be run if `GREETING` is already set in the environment.

From this perspective, this PR resolves #38.

In addition, a long-standing issue has been that the return value of `loadFile`/`loadContents` is pretty meaningless and not useful. To eliminate any possible confusion, I have changed the return values to `Aff Unit`, following stackbuilders/dotenv-hs#152.

Therefore, this also resolves #33.