### PR TITLE
Short-circuit circular references.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ New features:
 
 Bugfixes:
 - Handling of escaped quotes (#39 by @nsaunders)
+- Circular references are now short-circuited. (#41 by @nsaunders)
 
 Other improvements:
 - Unused values are no longer resolved. (#40 by @nsaunders)

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
         "purescript-either": "^v6.1.0",
         "purescript-exceptions": "^v6.0.0",
         "purescript-foldable-traversable": "^v6.0.0",
+        "purescript-lists": "v7.0.0",
         "purescript-maybe": "^v6.0.0",
         "purescript-node-buffer": "^v8.0.0",
         "purescript-node-child-process": "^v9.0.0",

--- a/spago.dhall
+++ b/spago.dhall
@@ -9,6 +9,7 @@
   , "either"
   , "exceptions"
   , "foldable-traversable"
+  , "lists"
   , "maybe"
   , "node-buffer"
   , "node-child-process"

--- a/src/Dotenv/Internal/Apply.purs
+++ b/src/Dotenv/Internal/Apply.purs
@@ -4,7 +4,6 @@ module Dotenv.Internal.Apply (apply) where
 
 import Prelude
 
-import Data.Array (filter) as A
 import Data.Maybe (isNothing)
 import Data.Traversable (for_, traverse_)
 import Data.Tuple.Nested ((/\))
@@ -24,6 +23,5 @@ apply settings =
   for_ settings \(name /\ unresolvedValue) -> do
     currentValue <- lookupEnv name
     when (isNothing currentValue) do
-      maybeValue <- resolve (A.filter (\(name' /\ _) -> name /= name') settings)
-        unresolvedValue
+      maybeValue <- resolve settings (pure name) unresolvedValue
       traverse_ (setEnv name) maybeValue


### PR DESCRIPTION
Consider this `.env`:

```
FOO=${BAR}
BAR=${FOO}
```

Prior to this change, the program would hang due to the circular reference. After this change, `FOO` and `BAR` will each resolve to `Nothing` and thus have no effect on the environment.